### PR TITLE
fix spacing between deferred notes

### DIFF
--- a/marginfix.dtx
+++ b/marginfix.dtx
@@ -654,8 +654,8 @@
       \noexpand\@cons\noexpand\@freelist#1%
       \noexpand\@cons\noexpand\@freelist#2%
     }%
+    \let\mfx@margin@skip\MFX@margin@skip@down
   \fi
-  \let\mfx@margin@skip\MFX@margin@skip@down
 %<debug>\MFX@debug{note@down: RETURN space=\the\Mfx@marginboxspace,
 %<debug>           pos=\the\Mfx@marginpos}%
 }


### PR DESCRIPTION
Fix spacing between deferred notes. Fixes #3

Fix based on comment from gilgamec (see issue #3).
`\marginparpush` and `\marginskip` now work as expected on deferred notes.

Reproducible example showing the problem and validating the fix:

``` latex
\documentclass{memoir}
\usepackage{lipsum}
\usepackage{marginfix}
\usepackage{color}
\marginparpush = 1cm
 \begin{document}
 \marginpar{\lipsum[2]}
 \lipsum[1]
 \marginpar{\color{red}\lipsum[2]}
 \lipsum[1]
 \marginpar{\lipsum[2]}
 \lipsum[1]
 \marginpar{\color{red}\lipsum[2]}
 \lipsum[1]
 \end{document}
```
