### PR TITLE
swap arguments to fix \marginpar[<left>]{<right>} behavior

### DIFF
--- a/marginfix.dtx
+++ b/marginfix.dtx
@@ -405,7 +405,7 @@
 %<debug>    \the\c@page:\the\@pageht, marginlist=\meaning\mfx@marginlist}%
   \MFX@getypos
   \MFX@cons\mfx@marginlist{% TODO: later this will be a run@marginlist
-    \noexpand\mfx@margin@note\@marbox\@currbox{\mfx@ypos}% (^i.e. for phantoms)
+    \noexpand\mfx@margin@note\@currbox\@marbox{\mfx@ypos}% (^i.e. for phantoms)
     \noexpand\mfx@margin@skip{\the\marginparpush}%
   }%
 %<debug>\MFX@debug{addmarginpar (exit): marginlist=\meaning\mfx@marginlist}%


### PR DESCRIPTION
Swapping arguments to fix `\marginpar[<left>]{<right>}` behavior. Fixes #1

`\marginpar[<left>]{<right>}` does not work correctly under marginfix v0.9.1.
The `<left>` and `<right>` notes are swapped.
Swapping arguments to fix `\marginpar[<left>]{<right>}` behavior.
