### PR TITLE
fix bug that causes \extendmargin to affect all pages

### DIFF
--- a/marginfix.dtx
+++ b/marginfix.dtx
@@ -497,7 +497,7 @@
 \def\MFX@combinefloats@before{%
   \MFX@buildmargin
   \MFX@attachmargin
-  \Mfx@marginheight\marginheightadjustment
+  \global\Mfx@marginheight\marginheightadjustment
 }
 %    \end{macrocode}
 % \end{macros}


### PR DESCRIPTION
Fix bug that causes \extendmargin to affect all pages. Fixes #2.
Fix is based on comment from gilgamec (see issue #2).
