### PR TITLE
fix bugs affecting \marginheightadjustment and \extendmargin

### DIFF
--- a/marginfix.dtx
+++ b/marginfix.dtx
@@ -495,9 +495,10 @@
 % we reuse the register for one-time extensions).
 %    \begin{macrocode}
 \def\MFX@combinefloats@before{%
+  \advance\Mfx@marginheight\marginheightadjustment
   \MFX@buildmargin
   \MFX@attachmargin
-  \Mfx@marginheight\marginheightadjustment
+  \global\Mfx@marginheight\z@
 }
 %    \end{macrocode}
 % \end{macros}


### PR DESCRIPTION
Fix bugs affecting \marginheightadjustment and \extendmargin. Fixes #2 and #4.
Fixes are based on comments from gilgamec (see #2 and #4)

Issue #2: \extendmargin applies to all pages in v0.9.1 (not current page only). That is due to the fact that `\Mfx@marginheight` is not reset to 0 at the end of `\MFX@combinefloats@before` due to a missing `\global` statement. Fix is based on comments from gilgamec(#2 and #4)

Issue #4: margin height adjustments applied by changing the `\marginheightadjustment` length in v0.9.1 are only applied after a new page; that is, they are not applied on the page where the length is changed. In particular, the \marginheightadjustment length never applies to the first page of the document, no matter where the length is changed. Fix is based on comment from gilgamec (#4)
