### PR TITLE
Some typos and a fix for issue #15

### DIFF
--- a/marginfix.dtx
+++ b/marginfix.dtx
@@ -12,10 +12,10 @@
 %
 %<package>\NeedsTeXFormat{LaTeX2e}
 %<package>\ProvidesPackage{marginfix}%
-           [2013/09/08 v1.1 Fix Margin Paragraphs]
+           [2020/05/05 v1.2 Fix Margin Paragraphs]
 %<*driver>
 \documentclass{ltxdoc}
-\CheckSum{1158}
+\CheckSum{1156}
 %\OnlyDescription % (un)comment this line to show (hide) source code
 \RecordChanges
 \EnableCrossrefs

--- a/marginfix.dtx
+++ b/marginfix.dtx
@@ -703,13 +703,13 @@
 % it for keeping track of available space in individual margin pieces.
 %    \begin{macrocode}
 \def\MFX@buildmargin{%
-  \advance\Mfx@marginheight\@colroom
+  \Mfx@marginheight=\@colroom
   \ifx\mfx@marginstart\relax
   \else
     \MFX@cons\mfx@marginpieces{%
       \noexpand\@elt{\mfx@marginstart}{\the\Mfx@marginheight}}%
     \gdef\mfx@marginstart{0pt}%
-    \global\advance\Mfx@piece@count\@ne
+    \global\Mfx@piece@count=\@ne
   \fi
 %<debug>\MFX@debug{buildmargin: marginheight=\the\Mfx@marginheight,
 %<debug>           marginlist=\MFX@mac\mfx@marginlist,

--- a/marginfix.dtx
+++ b/marginfix.dtx
@@ -512,7 +512,7 @@
 % In passing we'll define the cons macro, which fully-expands
 % its second argument, but makes sure to only expand the first
 % one once, so that any fragile control sequences in it are
-% corectly protected.  We also define snoc, which prepends.
+% correctly protected.  We also define snoc, which prepends.
 % Note that we could put the \cs{temp@} definition into a group
 % if it was really gonna matter\ldots
 %    \begin{macrocode}
@@ -784,7 +784,7 @@
 % We now define the various |\MFX@margin@...@down| macros.
 % At this stage in the game, the only difference between  notes
 % and skips is that we ignore skips before any notes by setting
-% \cs{mfx@build@note} initially to \cs{@gobble}.  Once we've
+% \cs{mfx@build@skip} initially to \cs{@gobble}.  Once we've
 % seen the first note, skips are treated exactly the same: as
 % fixed-height material.  If there is room in the current piece
 % for the given height, then we prepend it to \cs{mfx@marginout},
@@ -928,7 +928,7 @@
 % \end{macros}
 %
 % \begin{macros}{\MFX@leftmargin}
-% And here is the logic to figure out which margin were in, based
+%   And here is the logic to figure out which margin we're in, based
 % on the page number and other flags.  This is another conditional-like
 % macro, and should be used after an \cs{if}, as in
 % \cs{if}\cs{MFX@leftmargin}\ldots\cs{else}\ldots\cs{fi}.
@@ -1039,7 +1039,7 @@
 % look for a piece that can fit this note, making sure to decrement
 % the piece count and pop off a phantom for each new piece we check.
 % Once it's found, we add the note back to \cs{mfx@marginout} with
-% the corect piece.
+% the correct piece.
 %    \begin{macrocode}
   \if\MFX@check@fit{\advance\Mfx@piece@count\m@ne
                     \MFX@popdimen\dimen@\mfx@phantomheights}{\ht#1+\dp#1}%


### PR DESCRIPTION
I'm part of a [book project](https://github.com/UniMath/SymmetryBook/), where we are using marginfix to good effect. (So thank you!)

We were experiencing issue #15 frequently, so I looked into it briefly, and I think I found an easy fix, by resetting the variables in ```\MFX@buildmargin```. I was pointed in this direction by looking at the debug output, and finding that some notes where allocated to piece no. 2 on pages with a single piece.

However, I don't fully grok the internals of marginfix, so please check whether this change introduces unwanted side-effects, or whether the problem should be fixed in another manner.