### PR TITLE
Fix URL and space

### DIFF
--- a/marginfix.dtx
+++ b/marginfix.dtx
@@ -78,7 +78,7 @@
 % \title{\Lopt{marginfix} package documentation}
 % \author{Stephen Hicks\\%
 %    \texttt{sdh33@cornell.edu}\\%
-%    \texttt{http://shicks.github.com/marginfix}}
+%    \texttt{https://github.com/shicks/marginfix}}
 % \date{\fileversion{} -- \filedate}
 % \maketitle
 %
@@ -93,7 +93,7 @@
 % be mixed with sidebars.  This package implements a solution to
 % make marginpars "just work" by keeping a list of floating inserts and
 % arranging them intelligently in the output routine.  The credit for the
-% concept behind this algorithm goes to Prof. Andy Ruina, who employed me
+% concept behind this algorithm goes to Prof.\ Andy Ruina, who employed me
 % to work on some of his textbook macros in 2007--9.
 %
 % \section{Options}


### PR DESCRIPTION
Fixes the URL (given one is 404).

Fixes end-of-sentence spacing after "Prof."

<img width="1203" height="739" alt="grafik" src="https://github.com/user-attachments/assets/fe29b522-f33f-4fac-bc2a-2824ebf20c8f" />
